### PR TITLE
NAPS-48 Adds multi-select descriptor types

### DIFF
--- a/app/Descriptors.php
+++ b/app/Descriptors.php
@@ -30,6 +30,21 @@ class Descriptors extends Model
     }
 
     /**
+     * This is the validator for the Multi-Select value type.
+     */
+    private function validateMultiSelectType($values): bool
+    {
+        $isValid = true;
+        $values = explode(', ', $values);
+        foreach ($values as $selectedValue) {
+            if (!$this->validateSelectType(trim($selectedValue))) {
+                $isValid = false;
+            }
+        }
+        return $isValid;
+    }
+
+    /**
      * This is the validator for the Number value type.
      */
     private function validateNumberType($value): bool

--- a/resources/assets/js/components/pages/admin/categories/editor/Descriptors.vue
+++ b/resources/assets/js/components/pages/admin/categories/editor/Descriptors.vue
@@ -25,6 +25,7 @@
                 <template slot-scope="scope">
                     <el-select v-model="scope.row.value_type" @change="handleUpdate(scope.row)">
                         <el-option label="Select" value="select"></el-option>
+                        <el-option label="Multi-Select" value="multiSelect"></el-option>
                         <el-option label="Number" value="number"></el-option>
                     </el-select>
                 </template>
@@ -103,10 +104,24 @@
                     icon: ""
                 });
             },
-            parseAllowedValues (descriptor) {
-                return descriptor.allowed_values.split(",").map((value) => {
+            splitTrimJoin (string, splitOn, joinWith) {
+                return string.split(splitOn).map((value) => {
                     return value.trim();
-                }).join("|");
+                }).join(joinWith);
+            },
+            // method called by parseAllowedValues when parsing a "select" descriptor
+            parseAllowedSelectValues (descriptor) {
+                return this.splitTrimJoin(descriptor.allowed_values, ",", "|");
+            },
+            parseAllowedMultiSelectValues (descriptor) {
+                return this.parseAllowedSelectValues(descriptor);
+            },
+            parseAllowedNumberValues (descriptor) {
+                return this.splitTrimJoin(descriptor.allowed_values, "-", "-");
+            },
+            parseAllowedValues (descriptor) {
+                let parser = 'parseAllowed' + window.capitalize(descriptor.value_type) + 'Values';
+                return this[parser] ? this[parser](descriptor) : descriptor.allowed_values;
             },
             handleNewDescriptor (index, descriptor) {
                 let newDescriptor = {

--- a/resources/assets/js/components/pages/home/NewSpot.vue
+++ b/resources/assets/js/components/pages/home/NewSpot.vue
@@ -180,7 +180,7 @@
         },
         methods: {
             setupDescriptors() {
-                this.requiredDescriptors.forEach((descriptor)=>{
+                this.requiredDescriptors.forEach((descriptor) => {
                     this.$set(this.spotDescriptors, descriptor.name, '');
                 });
             },
@@ -256,7 +256,7 @@
                 if (!this.isPlopped) {
                     this.location = getMeta('googleMapsCenter');
                     if (navigator.geolocation) {
-                        navigator.geolocation.getCurrentPosition((position)=>{
+                        navigator.geolocation.getCurrentPosition((position) => {
                             self.location = {
                                 lat: position.coords.latitude,
                                 lng: position.coords.longitude,
@@ -327,7 +327,7 @@
             },
             verifyDescriptors() {
                 let allDescriptorsCompleted = true;
-                this.requiredDescriptors.forEach((descriptor)=>{
+                this.requiredDescriptors.forEach((descriptor) => {
                     let value = this.spotDescriptors[descriptor.name];
                     if (value === '') {
                         allDescriptorsCompleted = false;
@@ -340,7 +340,7 @@
             },
             parseDescriptors() {
                 let descriptorIDtoValue = {};
-                this.requiredDescriptors.forEach((descriptor)=>{
+                this.requiredDescriptors.forEach((descriptor) => {
                     let descriptorValue = this.spotDescriptors[descriptor.name];
                     descriptorIDtoValue[descriptor.id] =
                         typeof descriptorValue === 'object' ?

--- a/resources/assets/js/components/pages/home/NewSpot.vue
+++ b/resources/assets/js/components/pages/home/NewSpot.vue
@@ -162,7 +162,7 @@
                     let value = descriptor.default_value;
                     if (this.spotDescriptors[descriptor.name]) {
                         value = this.spotDescriptors[descriptor.name];
-                        if (typeof value === 'object') {
+                        if (Array.isArray(value)) {
                             value = value.join(', ');
                         }
                     }
@@ -343,7 +343,7 @@
                 this.requiredDescriptors.forEach((descriptor) => {
                     let descriptorValue = this.spotDescriptors[descriptor.name];
                     descriptorIDtoValue[descriptor.id] =
-                        typeof descriptorValue === 'object' ?
+                        Array.isArray(descriptorValue) ?
                             descriptorValue.join(', ') :
                             descriptorValue;
                 });

--- a/resources/assets/js/components/pages/home/NewSpot.vue
+++ b/resources/assets/js/components/pages/home/NewSpot.vue
@@ -62,8 +62,9 @@
                                 value=""
                                 size="small"
                                 class="full-width"
-                                v-if="descriptor.value_type === 'select'"
+                                v-if="descriptor.value_type.toLowerCase().includes('select')"
                                 v-model="spotDescriptors[descriptor.name]"
+                                :multiple="descriptor.value_type === 'multiSelect'"
                                 :placeholder="descriptor.name"
                                 @change="updatePloppedSpot"
                         >
@@ -161,6 +162,9 @@
                     let value = descriptor.default_value;
                     if (this.spotDescriptors[descriptor.name]) {
                         value = this.spotDescriptors[descriptor.name];
+                        if (typeof value === 'object') {
+                            value = value.join(', ');
+                        }
                     }
                     descriptor.pivot.value = value;
                     return descriptor;
@@ -337,7 +341,11 @@
             parseDescriptors() {
                 let descriptorIDtoValue = {};
                 this.requiredDescriptors.forEach((descriptor)=>{
-                    descriptorIDtoValue[descriptor.id] = this.spotDescriptors[descriptor.name];
+                    let descriptorValue = this.spotDescriptors[descriptor.name];
+                    descriptorIDtoValue[descriptor.id] =
+                        typeof descriptorValue === 'object' ?
+                            descriptorValue.join(', ') :
+                            descriptorValue;
                 });
                 return descriptorIDtoValue;
             },


### PR DESCRIPTION
[Link to the ticket](https://ritservices.atlassian.net/browse/NAPS-48)

**Issue summary** 
Descriptors are used to dynamically describe a given spot on attributes like Size, Quiet Level, Floor, Building, etc.. A multi-select descriptor type was needed in order to accommodate for Lab spots so we can list key software in the spot.

**Big-picture overview of solution and motivation**
I made every effort to minimize code complexity and duplication while adding this new descriptor. In that vein, a refactoring of how the admin panel handled parsing allowed values for a descriptor was needed. This made the frontend more closely match how the backend is structured, and makes future expansion easier.

**Testing**
No additional tests were written, due to upcoming [changes](https://ritservices.atlassian.net/browse/NAPS-34) that will modify the structure of how this project handles testing to make it more in line with a typical project.