### PR TITLE
NAPS-26 Reuse Descriptors

### DIFF
--- a/app/Http/Controllers/DescriptorController.php
+++ b/app/Http/Controllers/DescriptorController.php
@@ -74,6 +74,7 @@ class DescriptorController extends Controller
     public function update(Request $request, Descriptors $descriptor)
     {
         $rules = [
+            'category_id'       => 'sometimes|required|integer',
             'name'              => 'sometimes|required|string',
             'value_type'        => 'sometimes|required|string',
             'default_value'     => 'sometimes|required|string',
@@ -88,8 +89,12 @@ class DescriptorController extends Controller
         $updatedOne = false;
         foreach ($rules as $property => $rule) {
             if (Input::has($property)) {
-                $descriptor->$property = $request->input($property);
-                $descriptor->save();
+                if ($property == 'category_id') {
+                    $descriptor->categories()->attach($request->input('category_id'));
+                } else {
+                    $descriptor->$property = $request->input($property);
+                    $descriptor->save();
+                }
                 $updatedOne = true;
             }
         }

--- a/app/Http/Controllers/DescriptorController.php
+++ b/app/Http/Controllers/DescriptorController.php
@@ -18,6 +18,16 @@ class DescriptorController extends Controller
         $this->middleware('role_or_permission:admin|administer');
     }
 
+    public function list()
+    {
+        return Descriptors::all();
+    }
+
+    public function get($name)
+    {
+        return Descriptors::where('name', $name)->first();
+    }
+
     public function delete(Request $request, Descriptors $descriptor)
     {
         try {

--- a/resources/assets/js/components/pages/admin/categories/editor/CategoryEditor.vue
+++ b/resources/assets/js/components/pages/admin/categories/editor/CategoryEditor.vue
@@ -104,10 +104,6 @@
                             classification.availablePermissions = this.permissions;
                             return classification;
                         });
-                        console.log(this.category.classifications);
-                    })
-                    .catch(() => {
-                        //
                     });
             }
         },

--- a/resources/assets/js/components/pages/admin/categories/editor/Descriptors.vue
+++ b/resources/assets/js/components/pages/admin/categories/editor/Descriptors.vue
@@ -115,12 +115,9 @@
             handleSelect (index, descriptor) {
                 window.adminApi.get('spots/descriptor/' + descriptor.name)
                     .then((response) => {
+                        response.data.allowed_values.split("|").join(", ");
                         this.$set(this.descriptors, index, response.data);
-                        if (descriptor.temp) {
-                            this.handleNewDescriptor(index, this.descriptors[index]);
-                        } else {
-                            this.handleUpdate(this.descriptors[index]);
-                        }
+                        this.handleUpdate(this.descriptors[index], true);
                     });
             },
             insertTempDescriptor () {
@@ -164,14 +161,15 @@
                         });
                     });
             },
-            handleUpdate (descriptor) {
+            handleUpdate (descriptor, reuseDescriptor = false) {
                 if (!descriptor.temp) {
                     let updatedDescriptor = {
                         name: descriptor.name,
                         value_type: descriptor.value_type,
                         default_value: descriptor.default_value,
                         allowed_values: this.parseAllowedValues(descriptor),
-                        icon: descriptor.icon
+                        icon: descriptor.icon,
+                        category_id: reuseDescriptor ? this.categoryId : null
                     };
                     window.adminApi.post(`spots/descriptor/${descriptor.id}/update`, updatedDescriptor)
                         .then(() => {
@@ -223,7 +221,7 @@
                 window.adminApi.get('spots/descriptor/list')
                     .then((response) => {
                         this.allDescriptors = response.data.map((descriptor) => {
-                            return { 'value' : descriptor.name };
+                             return { 'value' : descriptor.name };
                         });
                     });
             }

--- a/routes/api.php
+++ b/routes/api.php
@@ -53,8 +53,10 @@ Route::prefix('admin')->middleware(['permission:administer'])->group(function ()
             });
         });
         Route::prefix('descriptor')->group(function () {
+            Route::get('list', 'DescriptorController@list');
             Route::post('create', 'DescriptorController@store');
             Route::prefix('{descriptor}')->group(function () {
+                Route::get('/', 'DescriptorController@get');
                 Route::post('update', 'DescriptorController@update');
                 Route::post('delete', 'DescriptorController@delete');
             });


### PR DESCRIPTION
[Link to the ticket](https://ritservices.atlassian.net/browse/NAPS-26)

**Issue summary**
Descriptors are pieces of information that each spot needs to have provided for it upon creation, based on the category they belong to. Several descriptors are shared among categories (like Building / Floor) and currently they have to be duplicated for each category that uses them.

**Big-picture overview of solution and motivation**
Implemented autocomplete on the descriptor field in the admin panel. When one of the suggestions is clicked on it will fill in all of the necessary information for that descriptor, and attach it to the category being edited.

**Testing**
No additional tests were written, due to upcoming changes that will modify the structure of how this project handles testing to make it more in line with a typical project.